### PR TITLE
P2r #311 app crashes for corrupted encrypted shared preferences store

### DIFF
--- a/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/EncryptedSharedPreferences.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/EncryptedSharedPreferences.kt
@@ -1,29 +1,100 @@
-/*
- * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
- * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
- * for Digital Health and Prevention -- A research institute of the
- * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
- * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
- */
 package io.redlink.more.more_app_mutliplatform.services.store
 
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import io.github.aakira.napier.Napier
+import java.io.File
+import java.security.GeneralSecurityException
+import javax.crypto.AEADBadTagException
 
 private const val ENCRYPT_SHARED_PREF_FILENAME = "credentials_file"
+private const val TAG = "EncryptedSharedPrefs"
+
+// TODO: Remove encrypted shared preferences after all active devices updated to this version
 class EncryptedSharedPreferences {
     companion object {
         fun create(context: Context): SharedPreferences {
+            return try {
+                createEncryptedSharedPreferences(context)
+            } catch (exception: AEADBadTagException) {
+                Napier.w(
+                    exception,
+                    tag = TAG
+                ) { "Failed to create EncryptedSharedPreferences, attempting recovery" }
+                handleEncryptionFailure(context, exception)
+            }
+        }
+
+        private fun createEncryptedSharedPreferences(context: Context): SharedPreferences {
             val masterKey = MasterKey.Builder(context)
                 .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
                 .build()
-            return EncryptedSharedPreferences.create(context, ENCRYPT_SHARED_PREF_FILENAME, masterKey, EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM)
+
+
+            return EncryptedSharedPreferences.create(
+                context,
+                ENCRYPT_SHARED_PREF_FILENAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        }
+
+        private fun handleEncryptionFailure(
+            context: Context,
+            exception: Exception
+        ): SharedPreferences = when (exception) {
+            is AEADBadTagException, is GeneralSecurityException -> {
+                Napier.w(tag = TAG) { "Encryption/decryption error detected, clearing corrupted data" }
+                clearCorruptedData(context)
+
+                try {
+                    createEncryptedSharedPreferences(context)
+                } catch (retryException: Exception) {
+                    Napier.e(
+                        retryException,
+                        tag = TAG
+                    ) { "Failed to create EncryptedSharedPreferences after recovery, falling back to regular SharedPreferences" }
+                    createFallbackSharedPreferences(context)
+                }
+            }
+
+            else -> {
+                Napier.e(
+                    exception,
+                    tag = TAG
+                ) { "Unexpected error creating EncryptedSharedPreferences, falling back to regular SharedPreferences" }
+                createFallbackSharedPreferences(context)
+            }
+        }
+
+        private fun clearCorruptedData(context: Context) {
+            try {
+                val sharedPrefsFile =
+                    context.getSharedPreferences(ENCRYPT_SHARED_PREF_FILENAME, Context.MODE_PRIVATE)
+                sharedPrefsFile.edit().clear().apply()
+
+                val prefsDir = context.filesDir.parent?.let { "$it/shared_prefs/" }
+                    ?: throw IllegalStateException("Failed to determine shared_prefs directory")
+                val prefsFile = File(prefsDir, "$ENCRYPT_SHARED_PREF_FILENAME.xml")
+                if (prefsFile.exists()) {
+                    prefsFile.delete()
+                }
+
+                Napier.i(tag = TAG) { "Successfully cleared corrupted encrypted preferences data" }
+            } catch (clearException: Exception) {
+                Napier.e(clearException, tag = TAG) { "Failed to clear corrupted data" }
+            }
+        }
+
+        private fun createFallbackSharedPreferences(context: Context): SharedPreferences {
+            Napier.w(tag = TAG) { "Using fallback unencrypted SharedPreferences - consider implementing additional security measures" }
+            return context.getSharedPreferences(
+                "${ENCRYPT_SHARED_PREF_FILENAME}_fallback",
+                Context.MODE_PRIVATE
+            )
         }
     }
 }

--- a/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/EncryptedSharedPreferences.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/EncryptedSharedPreferences.kt
@@ -1,3 +1,14 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
+
 package io.redlink.more.more_app_mutliplatform.services.store
 
 import android.content.Context

--- a/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/PrivateSharedPreferences.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/PrivateSharedPreferences.kt
@@ -1,0 +1,104 @@
+package io.redlink.more.more_app_mutliplatform.services.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.github.aakira.napier.Napier
+
+private const val PRIVATE_SHARED_PREF_FILENAME = "more_app_preferences"
+private const val ENCRYPT_SHARED_PREF_FILENAME = "credentials_file"
+private const val ENCRYPT_SHARED_PREF_FALLBACK_FILENAME = "${ENCRYPT_SHARED_PREF_FILENAME}_fallback"
+private const val TAG = "PrivateSharedPrefs"
+
+// This is a replacement key value store for the encrypted shared preferences, as those would crash the app if the key was not right anymore, like after an app reinstall, phone restore or phone transfer where the data were backed up, but the key did not.
+// TODO: Remove migration script after all active devices updated to this version
+class PrivateSharedPreferences {
+    companion object {
+        fun create(context: Context): SharedPreferences {
+            val privatePrefs = createPrivateSharedPreferences(context)
+
+            if (shouldMigrateFromEncrypted(context)) {
+                migrateFromEncryptedPreferences(context, privatePrefs)
+            }
+
+            return privatePrefs
+        }
+
+        private fun createPrivateSharedPreferences(context: Context): SharedPreferences {
+            return context.getSharedPreferences(
+                PRIVATE_SHARED_PREF_FILENAME,
+                Context.MODE_PRIVATE
+            )
+        }
+
+        private fun shouldMigrateFromEncrypted(context: Context): Boolean {
+            val encryptedPrefsFile =
+                context.getSharedPreferences(ENCRYPT_SHARED_PREF_FILENAME, Context.MODE_PRIVATE)
+            val fallbackPrefsFile = context.getSharedPreferences(
+                ENCRYPT_SHARED_PREF_FALLBACK_FILENAME,
+                Context.MODE_PRIVATE
+            )
+
+            return encryptedPrefsFile.all.isNotEmpty() || fallbackPrefsFile.all.isNotEmpty()
+        }
+
+        private fun migrateFromEncryptedPreferences(
+            context: Context,
+            privatePrefs: SharedPreferences
+        ) {
+            try {
+                Napier.i(tag = TAG) { "Starting migration from encrypted preferences" }
+
+                val encryptedPrefs = try {
+                    EncryptedSharedPreferences.create(context)
+                } catch (e: Exception) {
+                    Napier.w(
+                        e,
+                        tag = TAG
+                    ) { "Failed to access encrypted preferences, trying fallback" }
+                    context.getSharedPreferences(
+                        ENCRYPT_SHARED_PREF_FALLBACK_FILENAME,
+                        Context.MODE_PRIVATE
+                    )
+                }
+
+                val editor = privatePrefs.edit()
+
+                for ((key, value) in encryptedPrefs.all) {
+                    when (value) {
+                        is String -> editor.putString(key, value)
+                        is Boolean -> editor.putBoolean(key, value)
+                        is Int -> editor.putInt(key, value)
+                        is Float -> editor.putFloat(key, value)
+                        is Long -> editor.putLong(key, value)
+                        else -> Napier.w(tag = TAG) { "Unknown type for key: $key, value: $value" }
+                    }
+                }
+
+                editor.apply()
+
+                Napier.i(tag = TAG) { "Migration completed successfully" }
+
+                clearOldPreferences(context)
+            } catch (e: Exception) {
+                Napier.e(e, tag = TAG) { "Error during migration from encrypted preferences" }
+            }
+        }
+
+        private fun clearOldPreferences(context: Context) {
+            try {
+                context.getSharedPreferences(ENCRYPT_SHARED_PREF_FILENAME, Context.MODE_PRIVATE)
+                    .edit().clear().apply()
+
+                context.getSharedPreferences(
+                    ENCRYPT_SHARED_PREF_FALLBACK_FILENAME,
+                    Context.MODE_PRIVATE
+                )
+                    .edit().clear().apply()
+
+                Napier.i(tag = TAG) { "Old preferences cleared successfully" }
+            } catch (e: Exception) {
+                Napier.w(e, tag = TAG) { "Failed to clear old preferences" }
+            }
+        }
+    }
+}

--- a/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/SharedPreferencesRepository.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/more_app_mutliplatform/services/store/SharedPreferencesRepository.kt
@@ -14,7 +14,7 @@ import android.content.Context
 import android.content.SharedPreferences
 
 class SharedPreferencesRepository(context: Context) : SharedStorageRepository {
-    private var sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(context)
+    private var sharedPreferences: SharedPreferences = PrivateSharedPreferences.create(context)
 
     override fun store(key: String, value: String) {
         sharedPreferences

--- a/shared/src/commonMain/kotlin/io/redlink/more/more_app_mutliplatform/Shared.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/more_app_mutliplatform/Shared.kt
@@ -88,6 +88,8 @@ class Shared(
     private fun onApplicationStart() {
         if (credentialRepository.hasCredentials()) {
             activateObservationWatcher()
+        } else {
+            clearRemainingData()
         }
     }
 
@@ -272,6 +274,19 @@ class Shared(
             onDeletion()
             observationFactory.clearNeededObservationTypes()
             viewManager.resetAll()
+            studyStateRepository.storeState(StudyState.NONE)
+        }
+    }
+
+    private fun clearRemainingData() {
+        Napier.i { "Clearing remaining data..." }
+        stopObservations()
+        bluetoothController.resetAll()
+        Scope.launch {
+            removeStudyData()
+            observationFactory.clearNeededObservationTypes()
+            clearSharedStorage()
+            notificationManager.clearAllNotifications()
             studyStateRepository.storeState(StudyState.NONE)
         }
     }

--- a/shared/src/commonMain/kotlin/io/redlink/more/more_app_mutliplatform/viewModels/login/CoreLoginViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/more_app_mutliplatform/viewModels/login/CoreLoginViewModel.kt
@@ -17,20 +17,31 @@ import io.redlink.more.more_app_mutliplatform.services.network.openapi.model.Stu
 import io.redlink.more.more_app_mutliplatform.viewModels.CoreViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class CoreLoginViewModel(private val registrationService: RegistrationService): CoreViewModel() {
+class CoreLoginViewModel(private val registrationService: RegistrationService) : CoreViewModel() {
 
     val loadingFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
-    fun sendRegistrationToken(token: String, endpoint: String? = null, onSuccess: (Study) -> Unit, onError: (NetworkServiceError?) -> Unit) {
+    fun sendRegistrationToken(
+        token: String,
+        endpoint: String? = null,
+        onSuccess: (Study) -> Unit,
+        onError: (NetworkServiceError?) -> Unit
+    ) {
         if (token.isNotEmpty()) {
             loadingFlow.value = true
-            registrationService.sendRegistrationToken(token.uppercase(), endpoint, onSuccess, onError) {
+            registrationService.sendRegistrationToken(
+                token.uppercase(),
+                endpoint,
+                onSuccess,
+                onError
+            ) {
                 loadingFlow.value = false
             }
         }
     }
 
-    fun onLoadingChange(provideNewState: ((Boolean) -> Unit)) = loadingFlow.asClosure(provideNewState)
+    fun onLoadingChange(provideNewState: ((Boolean) -> Unit)) =
+        loadingFlow.asClosure(provideNewState)
 
     override fun viewDidAppear() {
 


### PR DESCRIPTION
- Added a new shared preferences in a private mode, restricting the data being accessible only by the app
- Implemented a migration script, that transfers the data from the old encrypted repository to the new one
- Added a fallback method, if the encrypted shared preferences fail to initialize, keeping the app from crashing, but leaving the user without credentials
- Made sure that left over data are cleaned in events, like corrupted credentials

Followup issue to remove the encrypted shared preferences: #312 