### PR TITLE
fix: remove duplicate Ktor JSON configuration in HttpClient setup

### DIFF
--- a/shared/src/androidMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
@@ -12,7 +12,6 @@ package io.redlink.more.services.network
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -20,12 +19,8 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
 
 actual fun getHttpClient(customLogger: Logger): HttpClient = HttpClient(Android) {
-    install(ContentNegotiation) {
-        json()
-    }
 
     defaultRequest {
         contentType(ContentType.Application.Json)

--- a/shared/src/iosMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
@@ -13,7 +13,6 @@ package io.redlink.more.services.network
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.auth.Auth
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -21,12 +20,8 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
 
 actual fun getHttpClient(customLogger: Logger): HttpClient = HttpClient(Darwin) {
-    install(ContentNegotiation) {
-        json()
-    }
 
     defaultRequest {
         contentType(ContentType.Application.Json)


### PR DESCRIPTION
Derzeit Zentrale Config in `getHttpClientWithAuth`. Alternativ könnte man die auch direkt in beide Plattform-spezifischen Clients verschieben -> Wäre dann doppelte Conf.