### PR TITLE
Update license headers to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ reasons, please consider checking through operating system settings that:
 
 ## License
 
-Apache 2.0 with Commons Clause; see LICENSE.txt for further details
+Apache 2.0; see LICENSE.txt for further details
 
 
 <!-- CONTACT -->

--- a/androidApp/src/main/java/io/redlink/more/app/android/MoreApplication.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/MoreApplication.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/ContentActivity.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/ContentActivity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/ContentViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/ContentViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/NavigationScreen.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/NavigationScreen.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/OnAppearDisappear.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/OnAppearDisappear.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/bluetooth/BluetoothActivity.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/bluetooth/BluetoothActivity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.bluetooth
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/bluetooth/BluetoothViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/bluetooth/BluetoothViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.bluetooth
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/completedSchedules/CompletedSchedulesView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/completedSchedules/CompletedSchedulesView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.completedSchedules
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/ConsentView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/ConsentView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.consent
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/ConsentViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/ConsentViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.consent
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/composables/ConsentButtons.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/composables/ConsentButtons.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.consent.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/DashboardView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/DashboardView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.dashboard
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/composables/FilterView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/composables/FilterView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.dashboard.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/filter/DashboardFilterView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/filter/DashboardFilterView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.dashboard.filter
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/filter/DashboardFilterViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/filter/DashboardFilterViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.dashboard.filter
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/schedule/ScheduleViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/schedule/ScheduleViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.dashboard.schedule
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/schedule/list/ScheduleListItem.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/schedule/list/ScheduleListItem.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.dashboard.schedule.list
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/schedule/list/ScheduleListView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/dashboard/schedule/list/ScheduleListView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.dashboard.schedule.list
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/info/InfoItem.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/info/InfoItem.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.info
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/info/InfoView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/info/InfoView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.info
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/info/InfoViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/info/InfoViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.info
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/leaveStudy/LeaveStudyConfirmView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/leaveStudy/LeaveStudyConfirmView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.setting.leave_study
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/leaveStudy/LeaveStudyView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/leaveStudy/LeaveStudyView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.setting.leave_study
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/leaveStudy/LeaveStudyViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/leaveStudy/LeaveStudyViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.leaveStudy
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/login/LoginView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/login/LoginView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.login
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/login/LoginViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/login/LoginViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.login
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/EndpointView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/EndpointView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.login.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/ErrorMessage.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/ErrorMessage.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.login.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/ParticipantKeyInput.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/ParticipantKeyInput.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.login.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/QRCodeButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/QRCodeButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.login.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/ValidationButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/login/composables/ValidationButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.login.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/main/MainActivity.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/main/MainActivity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.main
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/main/MainTabView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/main/MainTabView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.main
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/main/MainViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/main/MainViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.main
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/main/QRScannerActivity.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/main/QRScannerActivity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.qrScanner
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/main/composables/TabIcon.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/main/composables/TabIcon.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.main.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/NotificationView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/NotificationView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.notification
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/NotificationViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/NotificationViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.notification
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/composables/NotificationFilterViewButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/composables/NotificationFilterViewButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.notification.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/composables/NotificationItem.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/composables/NotificationItem.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.notification.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/filter/NotificationFilterView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/filter/NotificationFilterView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.notification.filter
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/filter/NotificationFilterViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/notification/filter/NotificationFilterViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.notification.filter
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorListView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorListView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observationErrors
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorListView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorListView.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.app.android.activities.observationErrors
 
 import android.app.Activity

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.observationErrors

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observationErrors
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observationErrors/ObservationErrorViewModel.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.app.android.activities.observationErrors
 
 import androidx.compose.runtime.mutableStateListOf

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/garmin/GarminConnectActivity.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/garmin/GarminConnectActivity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.observations.garmin

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/garmin/GarminConnectViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/garmin/GarminConnectViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.observations.garmin

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/limeSurvey/LimeSurveyActivity.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/limeSurvey/LimeSurveyActivity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.limeSurvey
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/limeSurvey/LimeSurveyViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/limeSurvey/LimeSurveyViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.limeSurvey
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionViewModel.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.app.android.activities.observations.questionnaire
 
 import androidx.compose.runtime.mutableStateOf

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireButtons.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireButtons.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireHeader.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireHeader.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireRadioButtons.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireRadioButtons.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireResponseView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireResponseView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/QuestionnaireView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/questionType/QuestionnaireCheckboxes.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/questionType/QuestionnaireCheckboxes.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire.questionType
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/questionType/QuestionnaireCheckboxes.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/questionType/QuestionnaireCheckboxes.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.app.android.activities.observations.questionnaire.questionType
 
 import androidx.compose.foundation.interaction.MutableInteractionSource

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/questionType/QuestionnaireQuestionAnswer.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/observations/questionnaire/questionType/QuestionnaireQuestionAnswer.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.observations.questionnaire.questionType
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/runningSchedules/RunningSchedulesView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/runningSchedules/RunningSchedulesView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.runningSchedules
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/setting/SettingsView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/setting/SettingsView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.setting
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/setting/SettingsViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/setting/SettingsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.setting
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/StudyDetailsView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/StudyDetailsView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyDetails
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/StudyDetailsViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/StudyDetailsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyDetails
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/composables/AccordionWithList.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/composables/AccordionWithList.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyDetails.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/composables/ObservationList.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/composables/ObservationList.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyDetails.composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/observationDetails/ObservationDetailsView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/observationDetails/ObservationDetailsView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyDetails.observationDetails
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/observationDetails/ObservationDetailsViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyDetails/observationDetails/ObservationDetailsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyDetails.observationDetails
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyClosedView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyClosedView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyStates
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyLoadingErrorView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyLoadingErrorView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.studyStates

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyLoadingView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyLoadingView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyStates
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyPausedView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyPausedView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyStates
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyUpdateView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/studyStates/StudyUpdateView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.studyStates
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/subcomponents/ExitButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/subcomponents/ExitButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.subcomponents

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/subcomponents/ReloadButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/subcomponents/ReloadButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.subcomponents
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/subcomponents/ReloadButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/subcomponents/ReloadButton.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.app.android.activities.subcomponents
 
 import androidx.compose.material.ButtonDefaults

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/taskCompletion/TaskCompletionBarView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/taskCompletion/TaskCompletionBarView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.taskCompletion
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/taskCompletion/TaskCompletionBarViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/taskCompletion/TaskCompletionBarViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.taskCompletion
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/tasks/ObservationActionButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/tasks/ObservationActionButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.tasks

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/tasks/TaskDetailsView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/tasks/TaskDetailsView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.tasks
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/tasks/TaskDetailsViewModel.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/tasks/TaskDetailsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.activities.tasks
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/web/WebClient.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/web/WebClient.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.web

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/web/WebClientListener.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/web/WebClientListener.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.activities.web

--- a/androidApp/src/main/java/io/redlink/more/app/android/broadcasts/NotificationBroadcastReceiver.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/broadcasts/NotificationBroadcastReceiver.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.broadcasts
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/extensions/ComposableExtensions.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/extensions/ComposableExtensions.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.extensions
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/extensions/DateTimeConversion.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/extensions/DateTimeConversion.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.extensions
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/extensions/MutableStateFlowExtension.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/extensions/MutableStateFlowExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.extensions
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/extensions/ResourceExtension.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/extensions/ResourceExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.extensions
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/extensions/ResourceMappingExtension.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/extensions/ResourceMappingExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.extensions
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/extensions/StringExtension.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/extensions/StringExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.extensions
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/firebase/FCMService.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/firebase/FCMService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.firebase
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidDataRecorder.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidDataRecorder.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidObservationDataManager.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidObservationDataManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidObservationFactory.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidObservationFactory.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidObservationPermissionObserver.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/AndroidObservationPermissionObserver.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.observations

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/GPS/GPSListener.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/GPS/GPSListener.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations.GPS
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/GPS/GPSObservation.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/GPS/GPSObservation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations.GPS
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/GPS/GPSService.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/GPS/GPSService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations.GPS
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/HR/PolarConnectorListener.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/HR/PolarConnectorListener.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations.HR
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/HR/PolarHeartRateObservation.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/HR/PolarHeartRateObservation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations.HR
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/HR/PolarObserverCallback.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/HR/PolarObserverCallback.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations.HR
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/ObservationExtension.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/ObservationExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.observations

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/ObservationManagerExtension.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/ObservationManagerExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.observations

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/ObservationServiceExtension.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/ObservationServiceExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.observations

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/PermissionUtils.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/PermissionUtils.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.observations

--- a/androidApp/src/main/java/io/redlink/more/app/android/observations/accelerometer/AccelerometerObservation.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/observations/accelerometer/AccelerometerObservation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.observations.accelerometer
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/services/LocalPushNotificationService.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/services/LocalPushNotificationService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.services
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/services/ObservationRecordingService.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/services/ObservationRecordingService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.services
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/services/bluetooth/PolarConnector.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/services/bluetooth/PolarConnector.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.services.bluetooth
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/services/sensorsListener/BluetoothStateListener.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/services/sensorsListener/BluetoothStateListener.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.services.sensorsListener

--- a/androidApp/src/main/java/io/redlink/more/app/android/services/sensorsListener/GPSStateListener.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/services/sensorsListener/GPSStateListener.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.services.sensorsListener

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/Accordion.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/Accordion.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/AccordionReadMore.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/AccordionReadMore.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ActivityProgressView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ActivityProgressView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/AppVersion.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/AppVersion.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/BasicText.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/BasicText.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/DatapointCollectionView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/DatapointCollectionView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/EmptyListView.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/EmptyListView.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ErrorMessage.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ErrorMessage.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/HeaderDescription.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/HeaderDescription.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/HeaderTitle.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/HeaderTitle.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/Heading.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/Heading.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/IconInline.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/IconInline.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MediumTitle.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MediumTitle.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MessageAlertDialog.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MessageAlertDialog.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MoreBackgroundComposable.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MoreBackgroundComposable.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MoreDivider.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/MoreDivider.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/NavigationBarTitle.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/NavigationBarTitle.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/NavigationText.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/NavigationText.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ScheduleList.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ScheduleList.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ScheduleListHeader.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/ScheduleListHeader.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SmallTextButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SmallTextButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SmallTextIconButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SmallTextIconButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SmallTitle.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SmallTitle.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SwipeButton.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/SwipeButton.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/TimeFrameDays.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/TimeFrameDays.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/TimeframeHours.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/TimeframeHours.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/Title.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/shared_composables/Title.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.shared_composables
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/theme/Color.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/theme/Color.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.theme
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/theme/Theme.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/theme/Theme.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.theme
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/theme/Type.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/theme/Type.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.theme
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/util/ActivityProvider.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/util/ActivityProvider.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.app.android.util

--- a/androidApp/src/main/java/io/redlink/more/app/android/util/AlarmUtils.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/util/AlarmUtils.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.app.android.util
 
 import android.app.AlarmManager

--- a/androidApp/src/main/java/io/redlink/more/app/android/util/AlarmUtils.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/util/AlarmUtils.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.util
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/util/logging/FirebaseCrashlyticsLog.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/util/logging/FirebaseCrashlyticsLog.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.util.logging
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/workers/DataUploadWorker.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/workers/DataUploadWorker.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.workers
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/workers/NotificationDataHandlerWorker.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/workers/NotificationDataHandlerWorker.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.workers
 

--- a/androidApp/src/main/java/io/redlink/more/app/android/workers/ScheduleUpdateWorker.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/workers/ScheduleUpdateWorker.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.workers
 

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import BackgroundTasks

--- a/iosApp/iosApp/AppState.swift
+++ b/iosApp/iosApp/AppState.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/BackgroundTasks/BackgroundTaskHandler.swift
+++ b/iosApp/iosApp/BackgroundTasks/BackgroundTaskHandler.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import BackgroundTasks

--- a/iosApp/iosApp/BackgroundTasks/DataUploadBackgroundTask.swift
+++ b/iosApp/iosApp/BackgroundTasks/DataUploadBackgroundTask.swift
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 import BackgroundTasks

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -4,9 +4,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 import shared
 import SwiftUI

--- a/iosApp/iosApp/ContentViewModel.swift
+++ b/iosApp/iosApp/ContentViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import BackgroundTasks

--- a/iosApp/iosApp/Extensions/ArrayExtension.swift
+++ b/iosApp/iosApp/Extensions/ArrayExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/BluetoothDeviceExtension.swift
+++ b/iosApp/iosApp/Extensions/BluetoothDeviceExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/Bundle.swift
+++ b/iosApp/iosApp/Extensions/Bundle.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/CMLogItemExtension.swift
+++ b/iosApp/iosApp/Extensions/CMLogItemExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CoreMotion

--- a/iosApp/iosApp/Extensions/CMSensorDataListExtension.swift
+++ b/iosApp/iosApp/Extensions/CMSensorDataListExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CoreMotion

--- a/iosApp/iosApp/Extensions/DateExtension.swift
+++ b/iosApp/iosApp/Extensions/DateExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/DictionaryExtension.swift
+++ b/iosApp/iosApp/Extensions/DictionaryExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/Int64Extension.swift
+++ b/iosApp/iosApp/Extensions/Int64Extension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/KotlinLongExtension.swift
+++ b/iosApp/iosApp/Extensions/KotlinLongExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/NavigationScreen.swift
+++ b/iosApp/iosApp/Extensions/NavigationScreen.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/NetworkServiceExtension.swift
+++ b/iosApp/iosApp/Extensions/NetworkServiceExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/ObservationExtension.swift
+++ b/iosApp/iosApp/Extensions/ObservationExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/RealmInstantExtension.swift
+++ b/iosApp/iosApp/Extensions/RealmInstantExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/StringExtension.swift
+++ b/iosApp/iosApp/Extensions/StringExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CryptoKit

--- a/iosApp/iosApp/Extensions/TimeIntervalExtension.swift
+++ b/iosApp/iosApp/Extensions/TimeIntervalExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Extensions/UISegmentedControlExtension.swift
+++ b/iosApp/iosApp/Extensions/UISegmentedControlExtension.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 import SwiftUI
 

--- a/iosApp/iosApp/Observations/AccelerometerBackgroundObservation.swift
+++ b/iosApp/iosApp/Observations/AccelerometerBackgroundObservation.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CoreMotion

--- a/iosApp/iosApp/Observations/AccelerometerObservation.swift
+++ b/iosApp/iosApp/Observations/AccelerometerObservation.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CoreMotion

--- a/iosApp/iosApp/Observations/GPSObservation.swift
+++ b/iosApp/iosApp/Observations/GPSObservation.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CoreLocation

--- a/iosApp/iosApp/Observations/IOSDataRecorder.swift
+++ b/iosApp/iosApp/Observations/IOSDataRecorder.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Observations/IOSObservationFactory.swift
+++ b/iosApp/iosApp/Observations/IOSObservationFactory.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Observations/ObservationActionDelegate.swift
+++ b/iosApp/iosApp/Observations/ObservationActionDelegate.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Observations/ObservationDataCollector.swift
+++ b/iosApp/iosApp/Observations/ObservationDataCollector.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Observations/PolarVerityHeartRateObservation.swift
+++ b/iosApp/iosApp/Observations/PolarVerityHeartRateObservation.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Observations/iOSObservationDataManager.swift
+++ b/iosApp/iosApp/Observations/iOSObservationDataManager.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Services/Bluetooth/IOSBluetoothConnector.swift
+++ b/iosApp/iosApp/Services/Bluetooth/IOSBluetoothConnector.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CoreBluetooth

--- a/iosApp/iosApp/Services/Bluetooth/PolarConnector.swift
+++ b/iosApp/iosApp/Services/Bluetooth/PolarConnector.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import CoreBluetooth

--- a/iosApp/iosApp/Services/DataUploadManager.swift
+++ b/iosApp/iosApp/Services/DataUploadManager.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Services/FCMService.swift
+++ b/iosApp/iosApp/Services/FCMService.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import FirebaseMessaging

--- a/iosApp/iosApp/Services/LocalPushNotificationService.swift
+++ b/iosApp/iosApp/Services/LocalPushNotificationService.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import FirebaseMessaging

--- a/iosApp/iosApp/Services/PermissionManager.swift
+++ b/iosApp/iosApp/Services/PermissionManager.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import AVFoundation

--- a/iosApp/iosApp/Services/PushNotificationSender.swift
+++ b/iosApp/iosApp/Services/PushNotificationSender.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Services/Semaphore.swift
+++ b/iosApp/iosApp/Services/Semaphore.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Style/MoreAnimation.swift
+++ b/iosApp/iosApp/Style/MoreAnimation.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Style/MoreBorder.swift
+++ b/iosApp/iosApp/Style/MoreBorder.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Style/MoreColor.swift
+++ b/iosApp/iosApp/Style/MoreColor.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Style/MoreContainer.swift
+++ b/iosApp/iosApp/Style/MoreContainer.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Style/MoreFont.swift
+++ b/iosApp/iosApp/Style/MoreFont.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Style/MoreFontWeight.swift
+++ b/iosApp/iosApp/Style/MoreFontWeight.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Style/MoreFrame.swift
+++ b/iosApp/iosApp/Style/MoreFrame.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Style/MoreImage.swift
+++ b/iosApp/iosApp/Style/MoreImage.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Style/MoreListStyleEdgeInsets.swift
+++ b/iosApp/iosApp/Style/MoreListStyleEdgeInsets.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Style/MoreTextFieldStyle.swift
+++ b/iosApp/iosApp/Style/MoreTextFieldStyle.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Style/MoreTextStyle.swift
+++ b/iosApp/iosApp/Style/MoreTextStyle.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Bluetooth/BluetoothConnectionView.swift
+++ b/iosApp/iosApp/Views/Bluetooth/BluetoothConnectionView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Bluetooth/BluetoothConnectionViewModel.swift
+++ b/iosApp/iosApp/Views/Bluetooth/BluetoothConnectionViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/CompletedSchedules/CompletedSchedules.swift
+++ b/iosApp/iosApp/Views/CompletedSchedules/CompletedSchedules.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Components/AccordionItem.swift
+++ b/iosApp/iosApp/Views/Components/AccordionItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Components/AppVersion.swift
+++ b/iosApp/iosApp/Views/Components/AppVersion.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/BasicNavLinkButton.swift
+++ b/iosApp/iosApp/Views/Components/BasicNavLinkButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/BasicText.swift
+++ b/iosApp/iosApp/Views/Components/BasicText.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/CircleActivityIndicator.swift
+++ b/iosApp/iosApp/Views/Components/CircleActivityIndicator.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ConsentList.swift
+++ b/iosApp/iosApp/Views/Components/ConsentList.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Components/ConsentListHeader.swift
+++ b/iosApp/iosApp/Views/Components/ConsentListHeader.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ConsentListItem.swift
+++ b/iosApp/iosApp/Views/Components/ConsentListItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Components/DatapointsCollection.swift
+++ b/iosApp/iosApp/Views/Components/DatapointsCollection.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/DetailsTitle.swift
+++ b/iosApp/iosApp/Views/Components/DetailsTitle.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/EmptyListView.swift
+++ b/iosApp/iosApp/Views/Components/EmptyListView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ErrorText.swift
+++ b/iosApp/iosApp/Views/Components/ErrorText.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ExpandableContent.swift
+++ b/iosApp/iosApp/Views/Components/ExpandableContent.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ExpandableContentWithLink.swift
+++ b/iosApp/iosApp/Views/Components/ExpandableContentWithLink.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ExpandableContentWithLinks.swift
+++ b/iosApp/iosApp/Views/Components/ExpandableContentWithLinks.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ExpandableInput.swift
+++ b/iosApp/iosApp/Views/Components/ExpandableInput.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ExpandableText.swift
+++ b/iosApp/iosApp/Views/Components/ExpandableText.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ForwardButton.swift
+++ b/iosApp/iosApp/Views/Components/ForwardButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/InactiveText.swift
+++ b/iosApp/iosApp/Views/Components/InactiveText.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/InlineAbortButton.swift
+++ b/iosApp/iosApp/Views/Components/InlineAbortButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ModuleListItem.swift
+++ b/iosApp/iosApp/Views/Components/ModuleListItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Components/MoreActionButton.swift
+++ b/iosApp/iosApp/Views/Components/MoreActionButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/MoreFilter.swift
+++ b/iosApp/iosApp/Views/Components/MoreFilter.swift
@@ -9,9 +9,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/MoreTextField.swift
+++ b/iosApp/iosApp/Views/Components/MoreTextField.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/MoreTextFieldHL.swift
+++ b/iosApp/iosApp/Views/Components/MoreTextFieldHL.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 import SwiftUI
 

--- a/iosApp/iosApp/Views/Components/MoreTextFieldSmBottom.swift
+++ b/iosApp/iosApp/Views/Components/MoreTextFieldSmBottom.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/Components/NavigationLinkButton.swift
+++ b/iosApp/iosApp/Views/Components/NavigationLinkButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/NavigationText.swift
+++ b/iosApp/iosApp/Views/Components/NavigationText.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/NotificationItem.swift
+++ b/iosApp/iosApp/Views/Components/NotificationItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Components/ObservatinoDetailsData.swift
+++ b/iosApp/iosApp/Views/Components/ObservatinoDetailsData.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/RadioButtonField.swift
+++ b/iosApp/iosApp/Views/Components/RadioButtonField.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ScheduleListHeader.swift
+++ b/iosApp/iosApp/Views/Components/ScheduleListHeader.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/SectionHeading.swift
+++ b/iosApp/iosApp/Views/Components/SectionHeading.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/Title.swift
+++ b/iosApp/iosApp/Views/Components/Title.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/Title2.swift
+++ b/iosApp/iosApp/Views/Components/Title2.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/UIToggleFoldViewButton.swift
+++ b/iosApp/iosApp/Views/Components/UIToggleFoldViewButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/ViewAdaptsToOpenKeyboard.swift
+++ b/iosApp/iosApp/Views/Components/ViewAdaptsToOpenKeyboard.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/Components/WebView/WebView.swift
+++ b/iosApp/iosApp/Views/Components/WebView/WebView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Components/WebView/WebViewViewModel.swift
+++ b/iosApp/iosApp/Views/Components/WebView/WebViewViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/Consent/ConsentView.swift
+++ b/iosApp/iosApp/Views/Consent/ConsentView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Consent/ConsentViewModel.swift
+++ b/iosApp/iosApp/Views/Consent/ConsentViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import AVFoundation

--- a/iosApp/iosApp/Views/Dashboard/DashboardView.swift
+++ b/iosApp/iosApp/Views/Dashboard/DashboardView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Info/ContactInfo.swift
+++ b/iosApp/iosApp/Views/Info/ContactInfo.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Info/InfoList.swift
+++ b/iosApp/iosApp/Views/Info/InfoList.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Info/InfoListItem.swift
+++ b/iosApp/iosApp/Views/Info/InfoListItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Info/InfoListItemModal.swift
+++ b/iosApp/iosApp/Views/Info/InfoListItemModal.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/Info/InfoView.swift
+++ b/iosApp/iosApp/Views/Info/InfoView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Info/InfoViewModel.swift
+++ b/iosApp/iosApp/Views/Info/InfoViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/LeaveStudy/LeavStudyModalState/LeaveStudyModalStateViewModel.swift
+++ b/iosApp/iosApp/Views/LeaveStudy/LeavStudyModalState/LeaveStudyModalStateViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/LeaveStudy/LeaveStudyConfirmationView.swift
+++ b/iosApp/iosApp/Views/LeaveStudy/LeaveStudyConfirmationView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/LeaveStudy/LeaveStudyView.swift
+++ b/iosApp/iosApp/Views/LeaveStudy/LeaveStudyView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/LimeSurvey/LimeSurveyView.swift
+++ b/iosApp/iosApp/Views/LimeSurvey/LimeSurveyView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/LimeSurvey/LimeSurveyViewModel.swift
+++ b/iosApp/iosApp/Views/LimeSurvey/LimeSurveyViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/Login/LoginButton.swift
+++ b/iosApp/iosApp/Views/Login/LoginButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Login/LoginQRCode/LoginQRCodeView.swift
+++ b/iosApp/iosApp/Views/Login/LoginQRCode/LoginQRCodeView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Login/LoginView.swift
+++ b/iosApp/iosApp/Views/Login/LoginView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Login/LoginViewModel.swift
+++ b/iosApp/iosApp/Views/Login/LoginViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/MainTabView.swift
+++ b/iosApp/iosApp/Views/MainTabView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/ModalView.swift
+++ b/iosApp/iosApp/Views/ModalView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/MoreMainBackgroundView.swift
+++ b/iosApp/iosApp/Views/MoreMainBackgroundView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Navigation.swift
+++ b/iosApp/iosApp/Views/Navigation.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/NavigationModalState.swift
+++ b/iosApp/iosApp/Views/NavigationModalState.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/Notification/Filter/NotificationFilterView.swift
+++ b/iosApp/iosApp/Views/Notification/Filter/NotificationFilterView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Notification/Filter/NotificationFilterViewModel.swift
+++ b/iosApp/iosApp/Views/Notification/Filter/NotificationFilterViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/Notification/NotificationView.swift
+++ b/iosApp/iosApp/Views/Notification/NotificationView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Notification/NotificationViewModel.swift
+++ b/iosApp/iosApp/Views/Notification/NotificationViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/ObservationDetails/ObservationDetailsView.swift
+++ b/iosApp/iosApp/Views/ObservationDetails/ObservationDetailsView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/ObservationDetails/ObservationDetailsViewModel.swift
+++ b/iosApp/iosApp/Views/ObservationDetails/ObservationDetailsViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/QuestionObservation/QuestionObservationView.swift
+++ b/iosApp/iosApp/Views/QuestionObservation/QuestionObservationView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/QuestionObservation/QuestionThankYouView.swift
+++ b/iosApp/iosApp/Views/QuestionObservation/QuestionThankYouView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/QuestionObservation/QuestionViewModel.swift
+++ b/iosApp/iosApp/Views/QuestionObservation/QuestionViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/RunningSchedules/RunningSchedules.swift
+++ b/iosApp/iosApp/Views/RunningSchedules/RunningSchedules.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Schedule/List/ObservationButton.swift
+++ b/iosApp/iosApp/Views/Schedule/List/ObservationButton.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Schedule/List/ObservationDetails.swift
+++ b/iosApp/iosApp/Views/Schedule/List/ObservationDetails.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Schedule/List/ObservationTimeDetails.swift
+++ b/iosApp/iosApp/Views/Schedule/List/ObservationTimeDetails.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/Schedule/List/QuestionListItem.swift
+++ b/iosApp/iosApp/Views/Schedule/List/QuestionListItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/Schedule/List/ScheduleList.swift
+++ b/iosApp/iosApp/Views/Schedule/List/ScheduleList.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Schedule/List/ScheduleListItem.swift
+++ b/iosApp/iosApp/Views/Schedule/List/ScheduleListItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Foundation

--- a/iosApp/iosApp/Views/Schedule/ScheduleView.swift
+++ b/iosApp/iosApp/Views/Schedule/ScheduleView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/Schedule/ScheduleViewModel.swift
+++ b/iosApp/iosApp/Views/Schedule/ScheduleViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Views/Settings/SettingsView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Views/Settings/SettingsViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import AppTrackingTransparency

--- a/iosApp/iosApp/Views/StudyDetails/ObservationListItem.swift
+++ b/iosApp/iosApp/Views/StudyDetails/ObservationListItem.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung 
-//  Licensed under the Apache 2.0 license with Commons Clause 
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/StudyDetails/StudyDetailsView.swift
+++ b/iosApp/iosApp/Views/StudyDetails/StudyDetailsView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/StudyDetails/StudyDetailsViewModel.swift
+++ b/iosApp/iosApp/Views/StudyDetails/StudyDetailsViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/StudyStates/StudyClosedView.swift
+++ b/iosApp/iosApp/Views/StudyStates/StudyClosedView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/StudyStates/StudyPausedView.swift
+++ b/iosApp/iosApp/Views/StudyStates/StudyPausedView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/StudyStates/StudyUpdateView.swift
+++ b/iosApp/iosApp/Views/StudyStates/StudyUpdateView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/TaskCompletionBar/TaskCompletionBarView.swift
+++ b/iosApp/iosApp/Views/TaskCompletionBar/TaskCompletionBarView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import shared

--- a/iosApp/iosApp/Views/TaskCompletionBar/TaskCompletionBarViewModel.swift
+++ b/iosApp/iosApp/Views/TaskCompletionBar/TaskCompletionBarViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/Views/TaskDetails/TaskDetailsView.swift
+++ b/iosApp/iosApp/Views/TaskDetails/TaskDetailsView.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import SwiftUI

--- a/iosApp/iosApp/Views/TaskDetails/TaskDetailsViewModel.swift
+++ b/iosApp/iosApp/Views/TaskDetails/TaskDetailsViewModel.swift
@@ -8,9 +8,7 @@
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 import Combine

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -9,9 +9,7 @@ import shared
 //  of the Ludwig Boltzmann Gesellschaft,
 //  Oesterreichische Vereinigung zur Foerderung
 //  der wissenschaftlichen Forschung
-//  Licensed under the Apache 2.0 license with Commons Clause
-//  (see https://www.apache.org/licenses/LICENSE-2.0 and
-//  https://commonsclause.com/).
+//  Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
 //
 
 

--- a/nwa.txt
+++ b/nwa.txt
@@ -4,7 +4,5 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL

--- a/shared/src/androidMain/kotlin/io/redlink/more/Platform.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/Platform.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/database/DatabaseManager.android.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/database/DatabaseManager.android.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database
 
 import android.content.Context

--- a/shared/src/androidMain/kotlin/io/redlink/more/database/DatabaseManager.android.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/database/DatabaseManager.android.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/extensions/asString.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/extensions/asString.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.models
 
 import android.content.Context

--- a/shared/src/androidMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.network
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/services/store/AndroidContext.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/services/store/AndroidContext.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/services/store/PrivateSharedPreferences.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/services/store/PrivateSharedPreferences.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/services/store/PrivateSharedPreferences.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/services/store/PrivateSharedPreferences.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services.store
 
 import android.content.Context

--- a/shared/src/androidMain/kotlin/io/redlink/more/services/store/SharedPreferencesRepository.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/services/store/SharedPreferencesRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/androidMain/kotlin/io/redlink/more/util/PlatformUtils.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/util/PlatformUtils.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.util

--- a/shared/src/androidMain/kotlin/io/redlink/more/util/UUID.kt
+++ b/shared/src/androidMain/kotlin/io/redlink/more/util/UUID.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.util
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/Platform.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/Platform.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/Shared.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/Shared.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/AppDatabase.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/AppDatabase.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.database

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/DatabaseManager.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/DatabaseManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/AggregatedObservationDataDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/AggregatedObservationDataDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/BaseDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/BaseDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/BluetoothDeviceDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/BluetoothDeviceDao.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.dao
 
 import androidx.room.Dao

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/BluetoothDeviceDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/BluetoothDeviceDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/DataPointDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/DataPointDao.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.dao
 
 import androidx.room.Dao

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/DataPointDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/DataPointDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/NotificationDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/NotificationDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/ObservationDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/ObservationDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/ObservationDataDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/ObservationDataDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/ScheduleDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/ScheduleDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/dao/StudyDao.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/dao/StudyDao.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.dao
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/AggregatedObservationDataEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/AggregatedObservationDataEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.database.entities

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/BluetoothDeviceEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/BluetoothDeviceEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/BluetoothDeviceEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/BluetoothDeviceEntity.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.entities
 
 import androidx.room.Entity

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/DataPointEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/DataPointEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/DataPointEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/DataPointEntity.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.entities
 
 import androidx.room.Entity

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/NotificationEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/NotificationEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ObservationDataEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ObservationDataEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ObservationEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ObservationEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ScheduleEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ScheduleEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ScheduleEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/ScheduleEntity.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.entities
 
 import androidx.room.Entity

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/StudyEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/StudyEntity.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/entities/StudyEntity.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/entities/StudyEntity.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.entities
 
 import androidx.room.Entity

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/migrations/Migration_1_2.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/migrations/Migration_1_2.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.migrations
 
 import androidx.room.migration.Migration

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/migrations/Migration_1_2.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/migrations/Migration_1_2.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.migrations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/migrations/Migration_2_3.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/migrations/Migration_2_3.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.database.migrations

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/AggregatedObservationDataRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/AggregatedObservationDataRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/AggregatedObservationDataRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/AggregatedObservationDataRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/BluetoothDeviceRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/BluetoothDeviceRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/BluetoothDeviceRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/BluetoothDeviceRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/DataPointCountRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/DataPointCountRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/DataPointCountRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/DataPointCountRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/MainRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/MainRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.database.repository

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/MainRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/MainRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.database.repository

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/NotificationRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/NotificationRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/NotificationRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/NotificationRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationDataRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationDataRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationDataRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationDataRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ObservationRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ScheduleRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ScheduleRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ScheduleRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/ScheduleRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/StudyRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/StudyRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/database/repository/StudyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/database/repository/StudyRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.repository
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/dialog/AlertController.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/dialog/AlertController.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.dialog

--- a/shared/src/commonMain/kotlin/io/redlink/more/dialog/AlertDialogModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/dialog/AlertDialogModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.dialog

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/AnyExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/AnyExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/CollectionExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/CollectionExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/CoroutineExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/CoroutineExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/DateTimeConverter.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/DateTimeConverter.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/FlowExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/FlowExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/FunctionExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/FunctionExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/FunctionExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/FunctionExtension.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.extensions
 
 infix fun (() -> Unit).then(after: () -> Unit): () -> Unit = { this(); after() }

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/ScheduleEntityExtenstion.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/ScheduleEntityExtenstion.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/ScheduleEntityExtenstion.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/ScheduleEntityExtenstion.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.extensions
 
 import io.redlink.more.database.entities.NotificationEntity

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/StringExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/StringExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/StringExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/StringExtension.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.extensions
 
 fun String.extractRouteFromDeepLink(): String? {

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/StudyStateExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/StudyStateExtension.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.extensions
 
 import io.redlink.more.models.StudyState

--- a/shared/src/commonMain/kotlin/io/redlink/more/extensions/StudyStateExtension.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/extensions/StudyStateExtension.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/logging/EventCollection.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/logging/EventCollection.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.logging

--- a/shared/src/commonMain/kotlin/io/redlink/more/logging/KMMLogger.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/logging/KMMLogger.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.logging

--- a/shared/src/commonMain/kotlin/io/redlink/more/logging/NapierProxy.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/logging/NapierProxy.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.logging
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/CredentialModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/CredentialModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/DateFilterModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/DateFilterModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/FilterModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/FilterModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/LoginModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/LoginModel.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.models
 
 import io.redlink.more.util.validateAndNormalizeUrl

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/LoginModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/LoginModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationFilterTypeModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationFilterTypeModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationStatusType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationStatusType.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.models
 
 enum class NotificationStatusType {

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationStatusType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationStatusType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.models
 
 import dev.icerock.moko.resources.desc.StringDesc

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextType.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.models
 
 import dev.icerock.moko.resources.desc.Resource

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/NotificationTextType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/ObservationDetailsModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/ObservationDetailsModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/PermissionConsentModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/PermissionConsentModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/PermissionModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/PermissionModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/QuestionModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/QuestionModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/QuestionType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/QuestionType.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.models
 
 enum class QuestionType(val observationType: String, val observationDataResponseKey: String) {

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/QuestionType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/QuestionType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/ScheduleListType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/ScheduleListType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/ScheduleModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/ScheduleModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/ScheduleState.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/ScheduleState.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/StudyDetailsModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/StudyDetailsModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/StudyState.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/StudyState.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/TaskCompletion.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/TaskCompletion.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/models/TaskDetailsModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/models/TaskDetailsModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManager.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManager.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.navigation
 
 import io.ktor.utils.io.core.Closeable

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManager.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.navigation
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManagerImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManagerImpl.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.navigation
 
 import io.github.aakira.napier.Napier

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManagerImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/DeeplinkManagerImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.navigation
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/DeepLinkData.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/DeepLinkData.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.navigation.model
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/DeepLinkData.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/DeepLinkData.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.navigation.model
 
 data class DeepLinkData(

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/NavigationRoute.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/NavigationRoute.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.navigation.model

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/NavigationRouteParameter.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/NavigationRouteParameter.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.navigation.model
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/NavigationRouteParameter.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/navigation/model/NavigationRouteParameter.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.navigation.model
 
 enum class NavigationRouteParameter(val key: String) {

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/DataConfig.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/DataConfig.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/DataRecorder.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/DataRecorder.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/Observation.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/Observation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationBulkModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationBulkModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationDataManager.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationDataManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationFactory.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationFactory.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationManager.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationStates.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationStates.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationStates.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/ObservationStates.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.observations
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/AppUsageObservation.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/AppUsageObservation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.appUsage

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/EventModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/EventModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.appUsage.model

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/InstantObservationPayload.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/InstantObservationPayload.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.appUsage.model

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/LogEvent.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/LogEvent.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.appUsage.model

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/RangeObservationPayload.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/appUsage/model/RangeObservationPayload.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.appUsage.model

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/garmin/GarminObservation.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/garmin/GarminObservation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.garmin
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/garmin/GarminObservation.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/garmin/GarminObservation.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.observations.garmin
 
 import io.redlink.more.database.repository.MainRepository

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/limesurvey/LimeSurveyObservation.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/limesurvey/LimeSurveyObservation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.limesurvey
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/longRunningObservation/DefaultLongRunningObservationStorage.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/longRunningObservation/DefaultLongRunningObservationStorage.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.longRunningObservation

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/longRunningObservation/InMemoryLongRunningObservationStorage.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/longRunningObservation/InMemoryLongRunningObservationStorage.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.longRunningObservation

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/longRunningObservation/LongRunningObservationStorage.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/longRunningObservation/LongRunningObservationStorage.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.longRunningObservation

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/AccelerometerType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/AccelerometerType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.observationTypes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/AppUsageObservationType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/AppUsageObservationType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.observationTypes

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/GPSType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/GPSType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.observationTypes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/GarminType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/GarminType.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.observations.observationTypes
 
 class GarminType : ObservationType("garmin-observation", emptySet(), prefix = PREFIX) {

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/GarminType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/GarminType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.observationTypes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/LimeSurveyType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/LimeSurveyType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.observationTypes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/ObservationType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/ObservationType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.observationTypes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/PolarVerityHeartRateType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/PolarVerityHeartRateType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.observationTypes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/QuestionType.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/observationTypes/QuestionType.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.observationTypes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/observations/questionObservation/QuestionObservation.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/observations/questionObservation/QuestionObservation.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations.questionObservation
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/registration/RegistrationService.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/registration/RegistrationService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.registration
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/registration/RegistrationService.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/registration/RegistrationService.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.registration
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreDispatchers.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreDispatchers.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.scopes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreDispatchers.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreDispatchers.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.scopes
 
 import kotlinx.coroutines.CoroutineDispatcher

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreScope.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreScope.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.scopes
 
 import kotlinx.coroutines.CoroutineScope

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreScope.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/MoreScope.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.scopes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/Scope.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/Scope.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.scopes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyMoreScope.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyMoreScope.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.scopes
 
 interface StudyMoreScope : MoreScope {

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyMoreScope.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyMoreScope.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.scopes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyScope.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyScope.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.scopes
 
 import kotlinx.coroutines.CoroutineScope

--- a/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyScope.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/scopes/StudyScope.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.scopes
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/ObservationService.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/ObservationService.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services
 
 import io.github.aakira.napier.Napier

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/ObservationService.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/ObservationService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothConnector.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothConnector.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.bluetooth
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothConnectorObserver.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothConnectorObserver.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.bluetooth
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothState.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothState.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.bluetooth
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothStateManagement.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothStateManagement.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services.bluetooth
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothStateManagement.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/BluetoothStateManagement.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.bluetooth
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/ScanMode.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/ScanMode.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services.bluetooth
 
 enum class ScanMode {

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/ScanMode.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/ScanMode.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.bluetooth
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/polar/PolarStates.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/polar/PolarStates.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.bluetooth.polar
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/polar/PolarStates.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/bluetooth/polar/PolarStates.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services.bluetooth.polar
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.network
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkClients.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkClients.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services.network
 
 import io.github.aakira.napier.Napier

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkClients.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkClients.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.network
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkService.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.network
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkServiceImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/network/NetworkServiceImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.network
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/network/errors/NetworkServiceError.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/network/errors/NetworkServiceError.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.app.android.services.network.errors
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/notification/NotificationActionHandler.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/notification/NotificationActionHandler.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services.notification
 
 enum class NotificationActionHandler {

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/notification/NotificationActionHandler.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/notification/NotificationActionHandler.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.notification
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/notification/NotificationManager.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/notification/NotificationManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.notification
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/store/CredentialRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/store/CredentialRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/store/CredentialRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/store/CredentialRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/store/EndpointRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/store/EndpointRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/store/EndpointRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/store/EndpointRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/store/PermissionRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/store/PermissionRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/store/PermissionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/store/PermissionRepositoryImpl.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/services/store/SharedStorageRepository.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/services/store/SharedStorageRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/FlowuUtils.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/FlowuUtils.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.util
 
 import kotlinx.coroutines.currentCoroutineContext

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/FlowuUtils.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/FlowuUtils.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.util
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/PlatformUtils.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/PlatformUtils.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.util

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/RegexData.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/RegexData.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.util
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/RegexData.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/RegexData.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.util
 
 class RegexData {

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/StringUtils.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/StringUtils.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.util
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/StringUtils.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/StringUtils.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.util
 
 /**

--- a/shared/src/commonMain/kotlin/io/redlink/more/util/UUID.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/util/UUID.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.util
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/CoreViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/CoreViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/ViewManager.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/ViewManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.viewModels

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/bluetoothConnection/BluetoothController.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/bluetoothConnection/BluetoothController.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.bluetoothConnection
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/bluetoothConnection/PolarController.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/bluetoothConnection/PolarController.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.bluetoothConnection
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/bluetoothConnection/PolarController.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/bluetoothConnection/PolarController.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.bluetoothConnection
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/dashboard/CoreDashboardFilterViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/dashboard/CoreDashboardFilterViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.dashboard
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/garminConnectOAuth/CoreGarminConnectViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/garminConnectOAuth/CoreGarminConnectViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.viewModels.garminConnectOAuth

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/limeSurvey/CoreLimeSurveyViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/limeSurvey/CoreLimeSurveyViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.limeSurvey
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/login/CoreLoginViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/login/CoreLoginViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.login
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationFilterViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationFilterViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.notifications
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.notifications
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/observationDetails/CoreObservationDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/observationDetails/CoreObservationDetailsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.observationDetails
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/permission/CoreConsentViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/permission/CoreConsentViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.permission
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/schedules/CoreScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/schedules/CoreScheduleViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.schedules
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/settings/CoreSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/settings/CoreSettingsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.settings
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/simpleQuestion/QuestionCoreViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/simpleQuestion/QuestionCoreViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.simpleQuestion
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/startupConnection/CoreBluetoothViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/startupConnection/CoreBluetoothViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.startupConnection
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/studydetails/CoreStudyDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/studydetails/CoreStudyDetailsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.studydetails
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/taskCompletionBar/CoreTaskCompletionBarViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/taskCompletionBar/CoreTaskCompletionBarViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.taskCompletionBar
 

--- a/shared/src/commonMain/kotlin/io/redlink/more/viewModels/tasks/CoreTaskDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/io/redlink/more/viewModels/tasks/CoreTaskDetailsViewModel.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.tasks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/database/entities/ObservationDataEntityTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/database/entities/ObservationDataEntityTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database.entities
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/database/entities/ObservationDataEntityTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/database/entities/ObservationDataEntityTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database.entities
 
 import kotlinx.datetime.Clock

--- a/shared/src/commonTest/kotlin/io/redlink/more/extensions/CollectionExtensionTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/extensions/CollectionExtensionTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.extensions
 
 import kotlin.test.Test

--- a/shared/src/commonTest/kotlin/io/redlink/more/extensions/CollectionExtensionTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/extensions/CollectionExtensionTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/extensions/StringExtensionTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/extensions/StringExtensionTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.extensions
 
 import kotlin.test.Test

--- a/shared/src/commonTest/kotlin/io/redlink/more/extensions/StringExtensionTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/extensions/StringExtensionTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/DatabaseMock.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/DatabaseMock.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.mocks

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/InMemoryStorageRepository.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/InMemoryStorageRepository.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.redlink.more.services.store.SharedStorageRepository

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/InMemoryStorageRepository.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/InMemoryStorageRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockBluetoothConnector.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockBluetoothConnector.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.redlink.more.database.entities.BluetoothDeviceEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockBluetoothConnector.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockBluetoothConnector.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDataRecorder.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDataRecorder.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.redlink.more.observations.DataRecorder

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDataRecorder.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDataRecorder.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDeeplinkManager.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDeeplinkManager.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.ktor.utils.io.core.Closeable

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDeeplinkManager.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockDeeplinkManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockLocalNotificationListener.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockLocalNotificationListener.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.redlink.more.database.entities.NotificationEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockLocalNotificationListener.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockLocalNotificationListener.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNetworkService.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNetworkService.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.ktor.http.Url

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNetworkService.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNetworkService.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationActionObserver.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationActionObserver.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.redlink.more.models.StudyState

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationActionObserver.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationActionObserver.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationManager.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationManager.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.mocks
 
 import io.redlink.more.database.repository.MainRepository

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationManager.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/MockNotificationManager.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.mocks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/RepositoryMocks.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/RepositoryMocks.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.mocks

--- a/shared/src/commonTest/kotlin/io/redlink/more/mocks/ServiceMocks.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/mocks/ServiceMocks.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.mocks

--- a/shared/src/commonTest/kotlin/io/redlink/more/navigation/DeeplinkManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/navigation/DeeplinkManagerTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.navigation
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/navigation/DeeplinkManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/navigation/DeeplinkManagerTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.navigation
 
 import io.redlink.more.database.entities.ScheduleEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/observations/InMemoryLongRunningObservationStorageTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/observations/InMemoryLongRunningObservationStorageTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations

--- a/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationDataManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationDataManagerTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationDataManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationDataManagerTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.observations
 
 import io.redlink.more.database.entities.ObservationDataEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationManagerTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.observations
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/observations/ObservationManagerTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.observations
 
 import io.redlink.more.database.entities.ObservationEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/observations/appUsage/AppUsageObservationTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/observations/appUsage/AppUsageObservationTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.observations.appUsage

--- a/shared/src/commonTest/kotlin/io/redlink/more/services/notification/NotificationManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/services/notification/NotificationManagerTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.services.notification
 
 import io.redlink.more.database.entities.NotificationEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/services/notification/NotificationManagerTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/services/notification/NotificationManagerTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.notification
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/login/CoreLoginViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/login/CoreLoginViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.login
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/login/CoreLoginViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/login/CoreLoginViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.login
 
 import io.redlink.more.Shared

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.notifications
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/notifications/CoreNotificationViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.notifications
 
 import io.redlink.more.Shared

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/observationDetails/CoreObservationDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/observationDetails/CoreObservationDetailsViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.observationDetails
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/observationDetails/CoreObservationDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/observationDetails/CoreObservationDetailsViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.observationDetails
 
 import io.redlink.more.database.entities.ObservationEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/permission/CoreConsentViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/permission/CoreConsentViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.permission
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/permission/CoreConsentViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/permission/CoreConsentViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.permission
 
 import io.redlink.more.Shared

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/schedules/CoreScheduleViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/schedules/CoreScheduleViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.schedules
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/schedules/CoreScheduleViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/schedules/CoreScheduleViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.schedules
 
 import io.redlink.more.database.repository.MainRepository

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/studydetails/CoreStudyDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/studydetails/CoreStudyDetailsViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.studydetails
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/studydetails/CoreStudyDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/studydetails/CoreStudyDetailsViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.studydetails
 
 import io.redlink.more.Shared

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/taskCompletionBar/CoreTaskCompletionBarViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/taskCompletionBar/CoreTaskCompletionBarViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.taskCompletionBar
 
 import io.redlink.more.database.entities.ScheduleEntity

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/taskCompletionBar/CoreTaskCompletionBarViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/taskCompletionBar/CoreTaskCompletionBarViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.taskCompletionBar
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/tasks/CoreTaskDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/tasks/CoreTaskDetailsViewModelTest.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.viewModels.tasks
 

--- a/shared/src/commonTest/kotlin/io/redlink/more/viewModels/tasks/CoreTaskDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/io/redlink/more/viewModels/tasks/CoreTaskDetailsViewModelTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.viewModels.tasks
 
 import io.redlink.more.database.entities.DataPointEntity

--- a/shared/src/iosMain/kotlin/io/redlink/more/Platform.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/Platform.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more
 

--- a/shared/src/iosMain/kotlin/io/redlink/more/database/DatabaseManager.ios.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/database/DatabaseManager.ios.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.database
 
 import androidx.room.Room

--- a/shared/src/iosMain/kotlin/io/redlink/more/database/DatabaseManager.ios.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/database/DatabaseManager.ios.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.database
 

--- a/shared/src/iosMain/kotlin/io/redlink/more/extensions/toString.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/extensions/toString.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.extensions
 

--- a/shared/src/iosMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.models
 

--- a/shared/src/iosMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/models/NotificationTextLocalization.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Apache 2.0 license with Commons Clause
+ * (see https://www.apache.org/licenses/LICENSE-2.0 and
+ * https://commonsclause.com/).
+ */
 package io.redlink.more.models
 
 import dev.icerock.moko.resources.desc.StringDesc

--- a/shared/src/iosMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/services/network/HttpClientReceiver.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.network
 

--- a/shared/src/iosMain/kotlin/io/redlink/more/services/store/UserDefaultsRepository.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/services/store/UserDefaultsRepository.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.services.store
 

--- a/shared/src/iosMain/kotlin/io/redlink/more/util/PlatformUtils.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/util/PlatformUtils.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
 package io.redlink.more.util

--- a/shared/src/iosMain/kotlin/io/redlink/more/util/UUID.kt
+++ b/shared/src/iosMain/kotlin/io/redlink/more/util/UUID.kt
@@ -4,9 +4,7 @@
  * for Digital Health and Prevention -- A research institute of the
  * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
  * Förderung der wissenschaftlichen Forschung).
- * Licensed under the Apache 2.0 license with Commons Clause
- * (see https://www.apache.org/licenses/LICENSE-2.0 and
- * https://commonsclause.com/).
+ * Licensed under the Apache 2.0 license (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 package io.redlink.more.util
 


### PR DESCRIPTION
## License headers updated

Brings source-file license headers in line with `LICENSE.txt` (plain **Apache 2.0**):

- Added the Apache 2.0 license header to Kotlin source files that were missing one.
- Removed **Commons Clause** from all license headers (Kotlin, Swift, Gradle), the `nwa.txt` template, and the README, so every header matches `LICENSE.txt` (plain Apache 2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)